### PR TITLE
Fix memory leak

### DIFF
--- a/include/TreeCache.h
+++ b/include/TreeCache.h
@@ -139,6 +139,8 @@ inline bool TreeCache::add_to_cache(InternalNode *page) {
           if (v < 0) {
             evict();
           }
+        } else {
+          safely_delete(ptr);
         }
         return true;
       }


### PR DESCRIPTION
Hi.

I've been trying to run CHIME on my environment but continuously faced out of memory issues on small sized cache settings.
My physical server has 256GB DRAM which I thought is quite enough to run client side operations.

Looking into some code snippets, I think memory leak is occurring at TreeCache::add_to_cache(InternalNode* page) line 135.
After successful CAS from a non-null pointer to a new pointer, the original non-null pointer is not correctly freed.

At least in my environment, I have confirmed that the out of memory issue is removed after applying this change.